### PR TITLE
2016-04-05 進めた分

### DIFF
--- a/mysite/polls/models.py
+++ b/mysite/polls/models.py
@@ -11,7 +11,8 @@ class Question(models.Model):
         return self.question_text
 
     def was_published_recently(self):
-        return self.pub_date >= timezone.now() - datetime.timedelta(days=1)
+        now = timezone.now()
+        return now - datetime.timedelta(days=1) <= self.pub_date <= now
 
 class Choice(models.Model):
     question = models.ForeignKey(Question, on_delete=models.CASCADE)

--- a/mysite/polls/templates/polls/index.html
+++ b/mysite/polls/templates/polls/index.html
@@ -1,9 +1,9 @@
-<h1>{{ question.question_text }}</h1>
-
-<ul>
-{% for choice in question.choice_set.all %}
-    <li>{{ choice.choice_text }} -- {{ choice.votes }} vote{{ choice.votes|pluralize }}</li>
-{% endfor %}
-</ul>
-
-<a href="{% url 'polls:detail' question.id %}">Vote again?</a>
+{% if latest_question_list %}
+    <ul>
+    {% for question in latest_question_list %}
+        <li><a href="{% url 'polls:detail' question.id %}/">{{ question.question_text }}</a></li>
+    {% endfor %}
+    </ul>
+{% else %}
+    <p>No polls are available.</p>
+{% endif %}

--- a/mysite/polls/tests.py
+++ b/mysite/polls/tests.py
@@ -1,3 +1,19 @@
+import datetime
+
+from django.test import TestCase
+from django.utils import timezone
 from django.test import TestCase
 
-# Create your tests here.
+from .models import Question
+
+
+class QuestionMethodTests(TestCase):
+
+    def test_was_published_recently_with_future_question(self):
+        """
+        was_published_recently() should return False for question whose
+        pub_date is in the future.
+        """
+        time = timezone.now() + datetime.timedelta(days=30)
+        future_question = Question(pub_date=time)
+        self.assertEqual(future_question.was_published_recently(), False)

--- a/mysite/polls/tests.py
+++ b/mysite/polls/tests.py
@@ -17,3 +17,14 @@ class QuestionMethodTests(TestCase):
         time = timezone.now() + datetime.timedelta(days=30)
         future_question = Question(pub_date=time)
         self.assertEqual(future_question.was_published_recently(), False)
+
+
+    def test_was_published_recently_with_old_question(self):
+        """
+        was_published_recently() should return False for questions whose
+        pub_date is older than 1day.
+        """
+        time = timezone.now() - datetime.timedelta(days=30)
+        old_question = Question(pub_date=time)
+        self.assertEqual(old_question.was_published_recently(), False)
+

--- a/mysite/polls/tests.py
+++ b/mysite/polls/tests.py
@@ -28,3 +28,11 @@ class QuestionMethodTests(TestCase):
         old_question = Question(pub_date=time)
         self.assertEqual(old_question.was_published_recently(), False)
 
+    def test_was_published_recently_with_recent_question(self):
+        """
+        was_published_recently() should return True for questions whose
+        pub_date is within the last day.
+        """
+        time = timezone.now() - datetime.timedelta(hours=1)
+        recent_question = Question(pub_date=time)
+        self.assertEqual(recent_question.was_published_recently(), True)


### PR DESCRIPTION
Part5途中まで、Django テストクライアントの途中まででおしまい。
- 写経は順調
- deoplete.nvim + deoplete-jedi + jedi-vim  結構快適になってた
- テストが変なコケ方するとおもってこれまでのチュートリアル振り返ったら誤植っぽいヶ所を発見
  - https://docs.djangoproject.com/ja/1.9/intro/tutorial04/  の 「それでは polls/index.html テンプレートを作成します」の部分、正しくは `polls/results.html` だと思われる。
  - a4299d6c666723bb03101748df77bfd2693e19a6 の index 分を戻した
